### PR TITLE
mysqlだけdockerに載せる

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=
+DB_DATABASE=rackle

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 
 # for credentials
 *.env
-
+initdb.d/*.sql.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.3'
+
+services:
+  db:
+    image: mysql:5.7
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --innodb-file-format=Barracuda
+      - --innodb-file-per-table=On
+      - --innodb-large-prefix=true
+      - --explicit-defaults-for-timestamp=true
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=rackle
+    volumes:
+      - type: bind
+        source: ./initdb.d
+        target: /docker-entrypoint-initdb.d
+      - ./mysql/conf.d:/etc/mysql/conf.d
+    ports:
+      - "3306:3306"

--- a/mysql/conf.d/my.cnf
+++ b/mysql/conf.d/my.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+character-set-server = utf8mb4
+[mysql]
+default-character-set = utf8mb4


### PR DESCRIPTION
`./initdb.d/`というDirを作成しその配下に初期データとして投入したいSQL(.sql, .sql.gz)を置いた状態で
`docker-compose up`をすれば求めてるMysqlがサクッと立ち上がる


## MEMO 
```
    environment:
      - MYSQL_ROOT_PASSWORD=root
      - MYSQL_DATABASE=rackle
```
docker-composeの設定においてMysqlを↑のようにしているため、connection.jsとの齟齬がないように各自調整をすること